### PR TITLE
Fix for not being able to load messages with bungee

### DIFF
--- a/Bungee/src/main/java/com/ayanix/panther/impl/bungee/locale/BungeeLocale.java
+++ b/Bungee/src/main/java/com/ayanix/panther/impl/bungee/locale/BungeeLocale.java
@@ -65,19 +65,21 @@ public class BungeeLocale extends BungeeYAMLStorage implements Locale
 	{
 		for (String key : getConfig().getKeys())
 		{
-			Configuration section = getConfig().getSection(key);
-
-			if (section != null)
+			if (getConfig().isList(key) || getConfig().isString(key))
 			{
-				for (String innerKey : section.getKeys())
-				{
-					loadMessage(key + "." + innerKey);
-				}
-
-				continue;
+				loadMessage(key);
+			} else
+			{
+    			Configuration section = getConfig().getSection(key);
+    
+    			if (section != null)
+    			{
+    				for (String innerKey : section.getKeys())
+    				{
+    					loadMessage(key + "." + innerKey);
+    				}
+    			}
 			}
-
-			loadMessage(key);
 		}
 	}
 


### PR DESCRIPTION
Otherwise it's not able to load messages with Bungee as it the plugin is crashing with a "unable to cast from String to Configuration" exception